### PR TITLE
Remove stalls when navigating large projects

### DIFF
--- a/P4VS/Preferences/Preferences.cs
+++ b/P4VS/Preferences/Preferences.cs
@@ -601,7 +601,7 @@ namespace Perforce.P4VS
 
 		private void RefreshAppData(bool writing)
 		{
-			if (!string.IsNullOrEmpty(_appData) && File.Exists(_appData))
+			if (!string.IsNullOrEmpty(_appData))
 			{
 				// Only check to see if another dev studio instance has changed the prefeneces if it's 
 				// been more than .1 seconds since we last checked


### PR DESCRIPTION
When clicking on a folder in the solution explorer that contained
many files (e.g. 5000), P4VS would hang due to the sheer number
of calls to `File.Exists()` in `LocalPreferenceCache.RefreshAppData()`.

Checking if the file exists is unnecessary since `File.GetLastWriteTime()`
[returns Jan 1, 1601 when the file is missing](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.getlastwritetime#remarks). This value will
be newer than `DateTime.MinValue`, causing one initial load attempt
that will internally discover that the file does not exist.

In a 5000-file project with Lazy Load _enabled_ and Full Context Menu _disabled_,
clicking on the root folder of the project in the solution explorer would cause
a 40-second hang. With this change, it is now barely noticeable.