### PR TITLE
Added a check in the `Dispose(bool disposing)` method to return early if the object has already been disposed.

### DIFF
--- a/P4VS/SwarmAPI/SSLCertificateHandler.cs
+++ b/P4VS/SwarmAPI/SSLCertificateHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -19,8 +16,7 @@ namespace Perforce.SwarmApi
         {
             ServerUrl = serverUrl;
             // Override automatic validation of SSL server certificates.
-            ServicePointManager.ServerCertificateValidationCallback =
-                   ValidateServerCertficate;
+            ServicePointManager.ServerCertificateValidationCallback = ValidateServerCertficate;
         }
 
         /// <summary>
@@ -43,21 +39,24 @@ namespace Perforce.SwarmApi
                 SslPolicyErrors sslPolicyErrors);
 
         #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
+        private bool isDisposed = false;
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (isDisposed)
             {
-                if (disposing)
-                {
-                    ServicePointManager.ServerCertificateValidationCallback = null;
-                }
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
+                return;
             }
+
+            if (disposing)
+            {
+                ServicePointManager.ServerCertificateValidationCallback = null;
+            }
+
+            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+            // TODO: set large fields to null.
+
+            isDisposed = true;
         }
 
         // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
@@ -71,8 +70,7 @@ namespace Perforce.SwarmApi
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
+            GC.SuppressFinalize(this);
         }
         #endregion
     }


### PR DESCRIPTION
* Removed unused `using` directives.
* Renamed `disposedValue` to `isDisposed` for better readability.
* Added a check in the `Dispose(bool disposing)` method to return early if the object has already been disposed.
* Called `GC.SuppressFinalize(this)` in the `Dispose()` method to prevent the finalizer from being called after the object has been disposed.